### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "ruby"
+run = "bin/console"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # BGG Hotness CLI
 
+[![Run on Repl.it](https://repl.it/badge/github/imjoshellis/BGG-Hotness-CLI)](https://repl.it/github/imjoshellis/BGG-Hotness-CLI)
+
 ## Todo
 
 - [ ] Set up Gem (fix gemspec)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).